### PR TITLE
USB Gadget HAL: Avoid crashes while switching between configs

### DIFF
--- a/Usb.cpp
+++ b/Usb.cpp
@@ -67,6 +67,7 @@ static int32_t readFile(const std::string &filename, std::string *contents) {
   return -1;
 }
 
+#if 0
 static int32_t writeFile(const std::string &filename,
                          const std::string &contents) {
   FILE *fp;
@@ -87,6 +88,7 @@ static int32_t writeFile(const std::string &filename,
 
   return -1;
 }
+#endif
 
 std::string appendRoleNodeHelper(const std::string &portName,
                                  PortRoleType type) {

--- a/UsbGadget.cpp
+++ b/UsbGadget.cpp
@@ -31,6 +31,7 @@ constexpr int MAX_FILE_PATH_LENGTH = 256;
 constexpr int EPOLL_EVENTS = 10;
 constexpr bool DEBUG = false;
 constexpr int DISCONNECT_WAIT_US = 100000;
+constexpr int PULL_UP_DELAY = 500000;
 
 #define BUILD_TYPE "ro.build.type"
 #define GADGET_PATH "/config/usb_gadget/g1/"
@@ -92,6 +93,7 @@ static void *monitorFfs(void *param) {
   char buf[BUFFER_SIZE];
   bool writeUdc = true, stopMonitor = false;
   struct epoll_event events[EPOLL_EVENTS];
+  std::chrono::steady_clock::time_point disconnect;
 
   bool descriptorWritten = true;
   for (int i = 0; i < static_cast<int>(usbGadget->mEndpointList.size()); i++) {
@@ -102,11 +104,14 @@ static void *monitorFfs(void *param) {
   }
 
   // notify here if the endpoints are already present.
-  if (descriptorWritten && !!WriteStringToFile(GADGET_NAME, PULLUP_PATH)) {
-    lock_guard<mutex> lock(usbGadget->mLock);
-    usbGadget->mCurrentUsbFunctionsApplied = true;
-    gadgetPullup = true;
-    usbGadget->mCv.notify_all();
+  if (descriptorWritten) {
+    usleep(PULL_UP_DELAY);
+    if (!!WriteStringToFile(GADGET_NAME, PULLUP_PATH)) {
+      lock_guard<mutex> lock(usbGadget->mLock);
+      usbGadget->mCurrentUsbFunctionsApplied = true;
+      gadgetPullup = true;
+      usbGadget->mCv.notify_all();
+    }
   }
 
   while (!stopMonitor) {
@@ -142,15 +147,21 @@ static void *monitorFfs(void *param) {
           if (!descriptorPresent && !writeUdc) {
             if (DEBUG) ALOGI("endpoints not up");
             writeUdc = true;
-          } else if (descriptorPresent && writeUdc &&
-                     !!WriteStringToFile(GADGET_NAME, PULLUP_PATH)) {
-            lock_guard<mutex> lock(usbGadget->mLock);
-            usbGadget->mCurrentUsbFunctionsApplied = true;
-            ALOGI("GADGET pulled up");
-            writeUdc = false;
-            gadgetPullup = true;
-            // notify the main thread to signal userspace.
-            usbGadget->mCv.notify_all();
+            disconnect = std::chrono::steady_clock::now();
+          } else if (descriptorPresent && writeUdc) {
+            std::chrono::steady_clock::time_point temp = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::microseconds>(temp - disconnect).count() < PULL_UP_DELAY)
+              usleep(PULL_UP_DELAY);
+
+            if (!!WriteStringToFile(GADGET_NAME, PULLUP_PATH)) {
+              lock_guard<mutex> lock(usbGadget->mLock);
+              usbGadget->mCurrentUsbFunctionsApplied = true;
+              ALOGI("GADGET pulled up");
+              writeUdc = false;
+              gadgetPullup = true;
+              // notify the main thread to signal userspace.
+              usbGadget->mCv.notify_all();
+            }
           }
         }
       } else {
@@ -240,8 +251,15 @@ V1_0::Status UsbGadget::tearDownGadget() {
 
   if (mMonitorCreated) {
     uint64_t flag = 100;
+    unsigned long ret;
     // Stop the monitor thread by writing into signal fd.
-    write(mEventFd, &flag, sizeof(flag));
+    ret = TEMP_FAILURE_RETRY(write(mEventFd, &flag, sizeof(flag)));
+    if (ret < 0) {
+      ALOGE("Error writing errno=%d", errno);
+    } else if (ret < sizeof(flag)) {
+      ALOGE("Short write length=%zd", ret);
+    }
+    ALOGI("mMonitor signalled to exit");
     mMonitor->join();
     mMonitorCreated = false;
     ALOGI("mMonitor destroyed");
@@ -459,6 +477,8 @@ Return<void> UsbGadget::setCurrentUsbFunctions(
   if (status != Status::SUCCESS) {
     goto error;
   }
+
+  ALOGI("Returned from tearDown Gadget");
   // Leave the gadget pulled down to give time for the host to sense disconnect.
   usleep(DISCONNECT_WAIT_US);
 


### PR DESCRIPTION
Sleep only when time elapsed since the last disconnect
is less than the PULL_UP_DELAY. This ensures that the hal
does not miss the 2 second timeout while switching between
functions.

Also, enclose write within TEMP_FAILURE_RETRY to prevent
being returned from EINTR.

Tracked-On: OAM-88508
Signed-off-by: saranya <saranya.gopal@intel.com>